### PR TITLE
feat(functions): デモ機能バックエンド実装（#20）

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -19,6 +19,15 @@
         { "fieldPath": "takenAt", "order": "DESCENDING" }
       ]
     }
+    ,
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isDemo", "order": "ASCENDING" },
+        { "fieldPath": "demoExpiresAt", "order": "ASCENDING" }
+      ]
+    }
   ],
   "fieldOverrides": []
 }

--- a/functions/src/cleanupDemo.ts
+++ b/functions/src/cleanupDemo.ts
@@ -1,0 +1,82 @@
+// デモユーザー自動削除: 1時間おきに期限切れデモデータを削除
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+
+const db = () => admin.firestore();
+
+// バッチ削除ヘルパー（500件ずつ）
+async function deleteCollection(collection: string, field: string, uid: string): Promise<number> {
+  const snapshot = await db().collection(collection).where(field, '==', uid).get();
+  if (snapshot.empty) return 0;
+
+  let count = 0;
+  let batch = db().batch();
+  for (const doc of snapshot.docs) {
+    batch.delete(doc.ref);
+    count++;
+    if (count % 500 === 0) {
+      await batch.commit();
+      batch = db().batch();
+    }
+  }
+  if (count % 500 !== 0) {
+    await batch.commit();
+  }
+  return count;
+}
+
+// 期限切れデモユーザーを検索して全データを削除
+async function cleanupExpiredDemoUsers(): Promise<void> {
+  const now = admin.firestore.Timestamp.now();
+
+  const expiredUsers = await db().collection('users')
+    .where('isDemo', '==', true)
+    .where('demoExpiresAt', '<', now)
+    .get();
+
+  if (expiredUsers.empty) {
+    console.info('[cleanupDemoUsers] 期限切れデモユーザーなし');
+    return;
+  }
+
+  console.info(`[cleanupDemoUsers] 削除対象: ${expiredUsers.size}件`);
+
+  let deletedCount = 0;
+  for (const userDoc of expiredUsers.docs) {
+    const uid = userDoc.id;
+    try {
+      // 参照データを先に削除
+      await Promise.all([
+        deleteCollection('intakes', 'userId', uid),
+        deleteCollection('dailyCounts', 'userId', uid),
+        deleteCollection('errorLogs', 'uid', uid),
+      ]);
+
+      // 薬を削除
+      await deleteCollection('medications', 'userId', uid);
+
+      // ユーザードキュメント削除
+      await db().collection('users').doc(uid).delete();
+
+      // Firebase Auth アカウント削除
+      await admin.auth().deleteUser(uid);
+
+      deletedCount++;
+      console.info(`[cleanupDemoUsers] 削除完了: ${uid}`);
+    } catch (err) {
+      // 部分失敗でも続行（次回実行で再試行）
+      console.error(`[cleanupDemoUsers] 削除失敗: ${uid}`, err);
+    }
+  }
+
+  console.info(`[cleanupDemoUsers] 完了: ${deletedCount}/${expiredUsers.size}件削除`);
+}
+
+export const cleanupDemoUsers = onSchedule(
+  {
+    schedule: '0 * * * *',
+    timeZone: 'Asia/Tokyo',
+    region: 'asia-northeast1',
+  },
+  cleanupExpiredDemoUsers,
+);

--- a/functions/src/demo.ts
+++ b/functions/src/demo.ts
@@ -1,0 +1,160 @@
+// デモユーザー用初期データ投入 API
+import { Router, Request, Response } from 'express';
+import * as admin from 'firebase-admin';
+
+export const demoRouter = Router();
+const db = () => admin.firestore();
+
+// デモ用薬データ
+const DEMO_MEDICATIONS = [
+  { name: 'レキサルティ（1mg）', limitPerDay: 2, notifyEnabled: true, notifyAt: ['08:00'] },
+  { name: 'デパス（0.5mg）', limitPerDay: 3, notifyEnabled: true, notifyAt: ['08:00', '20:00'] },
+  { name: 'ルネスタ（2mg）', limitPerDay: 1, notifyEnabled: true, notifyAt: ['22:00'] },
+];
+
+// ブラウザ言語からサポート言語を判定
+function resolveLanguage(acceptLanguage: string | undefined): string {
+  if (!acceptLanguage) return 'en';
+  const primary = acceptLanguage.split(',')[0].trim().toLowerCase();
+  if (primary.startsWith('ja')) return 'ja';
+  if (primary.startsWith('id')) return 'id';
+  return 'en';
+}
+
+// 東京タイムゾーンの dateKey を取得
+function getDateKey(date: Date): string {
+  return date.toLocaleDateString('sv-SE', { timeZone: 'Asia/Tokyo' });
+}
+
+// POST /v1/demo/setup — デモ用初期データ投入
+demoRouter.post('/setup', async (req: Request, res: Response) => {
+  // Authorization ヘッダーから idToken を取得・検証
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Authorization header required.' } });
+  }
+
+  let decodedToken: admin.auth.DecodedIdToken;
+  try {
+    decodedToken = await admin.auth().verifyIdToken(authHeader.split('Bearer ')[1]);
+  } catch {
+    return res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token.' } });
+  }
+
+  // 匿名認証チェック
+  if (decodedToken.firebase.sign_in_provider !== 'anonymous') {
+    return res.status(403).json({ error: { code: 'FORBIDDEN', message: 'Only anonymous users can setup demo.' } });
+  }
+
+  const uid = decodedToken.uid;
+
+  // 二重セットアップ防止: 既にデモユーザーが存在する場合は 409
+  const existingUser = await db().collection('users').doc(uid).get();
+  if (existingUser.exists && existingUser.data()?.isDemo === true) {
+    return res.status(409).json({ error: { code: 'CONFLICT', message: 'Demo already set up.' } });
+  }
+
+  try {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const language = resolveLanguage(req.headers['accept-language']);
+
+    // ユーザードキュメント作成
+    await db().collection('users').doc(uid).set({
+      email: '',
+      language,
+      notificationToken: null,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      adFree: false,
+      notifyMethod: 'email',
+      isDemo: true,
+      demoExpiresAt: admin.firestore.Timestamp.fromDate(expiresAt),
+      demoEmail: null,
+    }, { merge: true });
+
+    // 薬の登録
+    const medRefs: Array<{ id: string; name: string; limitPerDay: number }> = [];
+    for (const med of DEMO_MEDICATIONS) {
+      const ref = db().collection('medications').doc();
+      await ref.set({
+        userId: uid,
+        name: med.name,
+        limitPerDay: med.limitPerDay,
+        notifyEnabled: med.notifyEnabled,
+        notifyAt: med.notifyAt,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+      medRefs.push({ id: ref.id, name: med.name, limitPerDay: med.limitPerDay });
+    }
+
+    // 直近3日分の服薬記録を生成
+    const intakePatterns = [
+      // 2日前
+      { dayOffset: -2, medIndex: 0, takenUnits: 1 },
+      { dayOffset: -2, medIndex: 1, takenUnits: 1 },
+      { dayOffset: -2, medIndex: 2, takenUnits: 1 },
+      // 1日前
+      { dayOffset: -1, medIndex: 0, takenUnits: 1 },
+      { dayOffset: -1, medIndex: 1, takenUnits: 2 },
+      { dayOffset: -1, medIndex: 2, takenUnits: 1 },
+      // 今日
+      { dayOffset: 0, medIndex: 0, takenUnits: 1 },
+      { dayOffset: 0, medIndex: 1, takenUnits: 1 },
+    ];
+
+    // 日別カウンターを集計するためのマップ
+    const dailyCountMap = new Map<string, number>();
+
+    for (const pattern of intakePatterns) {
+      const med = medRefs[pattern.medIndex];
+      const takenDate = new Date(now.getTime() + pattern.dayOffset * 24 * 60 * 60 * 1000);
+      // 服用時刻を設定（朝8時 JST = UTC-1時）
+      takenDate.setUTCHours(pattern.dayOffset === 0 ? Math.max(now.getUTCHours() - 1, 0) : 8 - 9);
+      takenDate.setUTCMinutes(0, 0, 0);
+      const dateKey = getDateKey(takenDate);
+      const counterKey = `${uid}_${med.id}_${dateKey}`;
+
+      // dailyCount を加算
+      const prevTotal = dailyCountMap.get(counterKey) ?? 0;
+      const totalToday = prevTotal + pattern.takenUnits;
+      dailyCountMap.set(counterKey, totalToday);
+
+      const intakeRef = db().collection('intakes').doc();
+      await intakeRef.set({
+        userId: uid,
+        medicationId: med.id,
+        medicationName: med.name,
+        limitPerDaySnapshot: med.limitPerDay,
+        takenUnits: pattern.takenUnits,
+        takenAt: admin.firestore.Timestamp.fromDate(takenDate),
+        dateKey,
+        isOverdose: totalToday > med.limitPerDay,
+        totalToday,
+        cancelled: false,
+        isOdLog: false,
+        moodTags: [],
+        memo: '',
+      });
+    }
+
+    // dailyCounts を書き込み
+    for (const [counterDocId, total] of dailyCountMap) {
+      const parts = counterDocId.split('_');
+      // counterDocId = "{userId}_{medicationId}_{dateKey}"
+      const medicationId = parts[1];
+      const dateKey = parts.slice(2).join('_');
+      await db().collection('dailyCounts').doc(counterDocId).set({
+        userId: uid,
+        medicationId,
+        dateKey,
+        total,
+      }, { merge: true });
+    }
+
+    return res.status(201).json({ message: 'Demo setup complete.', expiresAt: expiresAt.toISOString() });
+  } catch (err) {
+    console.error('[demo/setup] error:', err);
+    return res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Failed to setup demo.' } });
+  }
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { medicationsRouter } from './medications';
 import { intakesRouter } from './intakes';
 import { accountDeleteRouter } from './accountDelete';
 import { dataExportRouter } from './dataExport';
+import { demoRouter } from './demo';
 
 admin.initializeApp();
 
@@ -39,6 +40,7 @@ app.use('/v1/users', accountDeleteRouter);
 app.use('/v1/users', dataExportRouter);
 app.use('/v1/medications', medicationsRouter);
 app.use('/v1/intakes', intakesRouter);
+app.use('/v1/demo', demoRouter);
 
 // Functions v2 エクスポート（リージョン: 東京）
 export const api = onRequest(
@@ -47,3 +49,4 @@ export const api = onRequest(
 );
 
 export { sendMedicationReminders } from './notify';
+export { cleanupDemoUsers } from './cleanupDemo';

--- a/functions/src/notify.ts
+++ b/functions/src/notify.ts
@@ -59,13 +59,17 @@ export const sendMedicationReminders = onSchedule(
         if (activeMeds.length === 0) continue;
 
         if (notifyMethod === 'email') {
-          // メール通知
+          // メール通知: デモユーザーは demoEmail を優先使用
           let email: string | undefined;
-          try {
-            const authUser = await admin.auth().getUser(userId);
-            email = authUser.email;
-          } catch {
-            console.warn(`[sendMedicationReminders] auth.getUser failed for ${userId}`);
+          if (userData?.isDemo === true) {
+            email = userData.demoEmail || undefined;
+          } else {
+            try {
+              const authUser = await admin.auth().getUser(userId);
+              email = authUser.email;
+            } catch {
+              console.warn(`[sendMedicationReminders] auth.getUser failed for ${userId}`);
+            }
           }
           if (!email) {
             console.info('[sendMedicationReminders] skip email (no address)', { userId });

--- a/functions/src/tests/cleanupDemo.test.ts
+++ b/functions/src/tests/cleanupDemo.test.ts
@@ -1,0 +1,134 @@
+// cleanupDemoUsers のテスト
+export {};
+
+// onSchedule をモックしてハンドラー関数を直接取得
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((_config: unknown, handler: unknown) => handler),
+}));
+
+const mockQueryGet = jest.fn();
+const mockBatchDelete = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
+const mockDocDelete = jest.fn().mockResolvedValue(undefined);
+const mockDeleteUser = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('firebase-admin', () => {
+  const mod = {
+    initializeApp: jest.fn(),
+    apps: [],
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn().mockImplementation((name: string) => {
+          if (name === 'users') {
+            return {
+              where: jest.fn().mockReturnThis(),
+              get: mockQueryGet,
+              doc: jest.fn(() => ({
+                delete: mockDocDelete,
+              })),
+            };
+          }
+          // intakes, dailyCounts, errorLogs, medications
+          return {
+            where: jest.fn().mockReturnThis(),
+            get: jest.fn().mockResolvedValue({ empty: true, docs: [] }),
+          };
+        }),
+        batch: jest.fn(() => ({
+          delete: mockBatchDelete,
+          commit: mockBatchCommit,
+        })),
+      })),
+      {
+        Timestamp: {
+          now: jest.fn().mockReturnValue({ _seconds: Math.floor(Date.now() / 1000) }),
+        },
+      },
+    ),
+    auth: jest.fn(() => ({
+      deleteUser: mockDeleteUser,
+    })),
+  };
+  return mod;
+});
+
+import { cleanupDemoUsers } from '../cleanupDemo';
+
+const handler = cleanupDemoUsers as unknown as () => Promise<void>;
+
+beforeAll(() => {
+  jest.spyOn(console, 'info').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+});
+afterAll(() => jest.restoreAllMocks());
+beforeEach(() => jest.clearAllMocks());
+
+describe('cleanupDemoUsers', () => {
+  it('期限切れデモユーザーがない場合は何もしない', async () => {
+    mockQueryGet.mockResolvedValue({ empty: true, size: 0, docs: [] });
+
+    await handler();
+
+    expect(mockDocDelete).not.toHaveBeenCalled();
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledWith('[cleanupDemoUsers] 期限切れデモユーザーなし');
+  });
+
+  it('期限切れデモユーザーを削除する', async () => {
+    mockQueryGet.mockResolvedValue({
+      empty: false,
+      size: 1,
+      docs: [{ id: 'demo-user-1', data: () => ({ isDemo: true }) }],
+    });
+
+    await handler();
+
+    // ユーザードキュメント削除
+    expect(mockDocDelete).toHaveBeenCalled();
+    // Firebase Auth アカウント削除
+    expect(mockDeleteUser).toHaveBeenCalledWith('demo-user-1');
+    expect(console.info).toHaveBeenCalledWith(`[cleanupDemoUsers] 削除完了: demo-user-1`);
+  });
+
+  it('複数の期限切れデモユーザーを削除する', async () => {
+    mockQueryGet.mockResolvedValue({
+      empty: false,
+      size: 2,
+      docs: [
+        { id: 'demo-user-1', data: () => ({ isDemo: true }) },
+        { id: 'demo-user-2', data: () => ({ isDemo: true }) },
+      ],
+    });
+
+    await handler();
+
+    expect(mockDeleteUser).toHaveBeenCalledTimes(2);
+    expect(mockDeleteUser).toHaveBeenCalledWith('demo-user-1');
+    expect(mockDeleteUser).toHaveBeenCalledWith('demo-user-2');
+  });
+
+  it('1ユーザーの削除失敗でも他ユーザーの削除を続行する', async () => {
+    mockQueryGet.mockResolvedValue({
+      empty: false,
+      size: 2,
+      docs: [
+        { id: 'demo-fail', data: () => ({ isDemo: true }) },
+        { id: 'demo-ok', data: () => ({ isDemo: true }) },
+      ],
+    });
+    // 1人目の Auth 削除で失敗
+    mockDeleteUser
+      .mockRejectedValueOnce(new Error('Auth delete error'))
+      .mockResolvedValueOnce(undefined);
+
+    await handler();
+
+    // 2人目は正常に削除される
+    expect(mockDeleteUser).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledWith(
+      '[cleanupDemoUsers] 削除失敗: demo-fail',
+      expect.any(Error),
+    );
+    expect(console.info).toHaveBeenCalledWith('[cleanupDemoUsers] 削除完了: demo-ok');
+  });
+});

--- a/functions/src/tests/demo.test.ts
+++ b/functions/src/tests/demo.test.ts
@@ -1,0 +1,235 @@
+// demo（POST /v1/demo/setup）のテスト
+export {};
+
+const mockVerifyIdToken = jest.fn();
+const mockDocGet = jest.fn();
+const mockDocSet = jest.fn().mockResolvedValue(undefined);
+const mockCollectionDoc = jest.fn();
+let docIdCounter = 0;
+
+jest.mock('firebase-admin', () => {
+  const mod = {
+    initializeApp: jest.fn(),
+    apps: [],
+    firestore: Object.assign(
+      jest.fn(() => ({
+        collection: jest.fn().mockImplementation((name: string) => {
+          if (name === 'users') {
+            return {
+              doc: jest.fn((id: string) => ({
+                get: mockDocGet,
+                set: mockDocSet,
+                id,
+              })),
+            };
+          }
+          // medications, intakes, dailyCounts
+          return {
+            doc: mockCollectionDoc,
+          };
+        }),
+      })),
+      {
+        FieldValue: { serverTimestamp: jest.fn().mockReturnValue('mock-ts') },
+        Timestamp: {
+          fromDate: jest.fn((d: Date) => ({ toDate: () => d, _seconds: Math.floor(d.getTime() / 1000) })),
+        },
+      },
+    ),
+    auth: jest.fn(() => ({
+      verifyIdToken: mockVerifyIdToken,
+    })),
+  };
+  return mod;
+});
+
+const express = require('express');
+const request = require('supertest');
+
+let app: ReturnType<typeof express>;
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  const { demoRouter } = require('../demo');
+  app.use('/v1/demo', demoRouter);
+});
+
+beforeAll(() => {
+  jest.spyOn(console, 'info').mockImplementation();
+  jest.spyOn(console, 'error').mockImplementation();
+});
+afterAll(() => jest.restoreAllMocks());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  docIdCounter = 0;
+  mockCollectionDoc.mockImplementation(() => {
+    const id = `doc-${++docIdCounter}`;
+    return { id, set: mockDocSet };
+  });
+});
+
+describe('POST /v1/demo/setup', () => {
+  it('Authorization ヘッダーがない場合は 401', async () => {
+    const res = await request(app).post('/v1/demo/setup');
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('無効なトークンで 401', async () => {
+    mockVerifyIdToken.mockRejectedValue(new Error('Invalid token'));
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer invalid-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('匿名認証以外は 403', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'user-1',
+      firebase: { sign_in_provider: 'password' },
+    });
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('既にデモセットアップ済みの場合は 409', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'user-1',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isDemo: true }),
+    });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CONFLICT');
+  });
+
+  it('正常にデモデータを投入する', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'demo-user-1',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    // ユーザー未作成
+    mockDocGet.mockResolvedValue({ exists: false });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Accept-Language', 'ja');
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Demo setup complete.');
+    expect(res.body.expiresAt).toBeDefined();
+
+    // users ドキュメント作成
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDemo: true,
+        language: 'ja',
+        notifyMethod: 'email',
+        demoEmail: null,
+      }),
+      { merge: true },
+    );
+
+    // 薬3件 + intakes 8件 + dailyCounts が作成されている
+    // mockDocSet の呼び出し回数: 1(user) + 3(meds) + 8(intakes) + N(dailyCounts)
+    expect(mockDocSet.mock.calls.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('Accept-Language が英語の場合 language は en', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'demo-user-2',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({ exists: false });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Accept-Language', 'en-US');
+    expect(res.status).toBe(201);
+
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'en' }),
+      { merge: true },
+    );
+  });
+
+  it('Accept-Language がインドネシア語の場合 language は id', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'demo-user-3',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({ exists: false });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Accept-Language', 'id-ID');
+    expect(res.status).toBe(201);
+
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'id' }),
+      { merge: true },
+    );
+  });
+
+  it('Accept-Language が未知の場合は en', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'demo-user-4',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({ exists: false });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Accept-Language', 'fr-FR');
+    expect(res.status).toBe(201);
+
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'en' }),
+      { merge: true },
+    );
+  });
+
+  it('isDemo が false の既存ユーザーは通常ユーザーなのでセットアップ許可', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'user-existing',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({
+      exists: true,
+      data: () => ({ isDemo: false }),
+    });
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(201);
+  });
+
+  it('Firestore エラー時は 500', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      uid: 'demo-user-err',
+      firebase: { sign_in_provider: 'anonymous' },
+    });
+    mockDocGet.mockResolvedValue({ exists: false });
+    mockDocSet.mockRejectedValueOnce(new Error('Firestore error'));
+
+    const res = await request(app)
+      .post('/v1/demo/setup')
+      .set('Authorization', 'Bearer valid-token');
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+});

--- a/functions/src/tests/notify.test.ts
+++ b/functions/src/tests/notify.test.ts
@@ -154,6 +154,37 @@ describe('sendMedicationReminders', () => {
     expect(mockSendEmail).toHaveBeenCalledWith('user@example.com', 'ObatLog リマインダー', '<html>reminder</html>');
   });
 
+  it('デモユーザーは demoEmail からメール送信する', async () => {
+    medsQueryGet.mockResolvedValue({
+      empty: false, size: 1,
+      docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬Demo', limitPerDay: 3 }) }],
+    });
+    userDocGet.mockResolvedValue({
+      data: () => ({ notifyMethod: 'email', isDemo: true, demoEmail: 'demo@example.com' }),
+    });
+    counterDocGet.mockResolvedValue({ exists: false });
+
+    await handler();
+    // demoEmail を使って送信し、auth.getUser は呼ばない
+    expect(authGetUser).not.toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalledWith('demo@example.com', 'ObatLog リマインダー', '<html>reminder</html>');
+  });
+
+  it('デモユーザーで demoEmail 未設定の場合はスキップ', async () => {
+    medsQueryGet.mockResolvedValue({
+      empty: false, size: 1,
+      docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬Demo2', limitPerDay: 3 }) }],
+    });
+    userDocGet.mockResolvedValue({
+      data: () => ({ notifyMethod: 'email', isDemo: true, demoEmail: null }),
+    });
+    counterDocGet.mockResolvedValue({ exists: false });
+
+    await handler();
+    expect(authGetUser).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
   it('auth.getUser 失敗時はスキップ', async () => {
     medsQueryGet.mockResolvedValue({
       empty: false, size: 1,

--- a/functions/src/tests/users.test.ts
+++ b/functions/src/tests/users.test.ts
@@ -143,6 +143,30 @@ describe('PUT /v1/users/me', () => {
     expect(res.body.error.message).toContain('No valid fields');
   });
 
+  it('demoEmail を更新する', async () => {
+    const res = await request(app)
+      .put('/v1/users/me')
+      .send({ demoEmail: 'demo@example.com' });
+    expect(res.status).toBe(200);
+    expect(mockDocUpdate).toHaveBeenCalledWith({ demoEmail: 'demo@example.com' });
+  });
+
+  it('demoEmail を null にリセットできる', async () => {
+    const res = await request(app)
+      .put('/v1/users/me')
+      .send({ demoEmail: null });
+    expect(res.status).toBe(200);
+    expect(mockDocUpdate).toHaveBeenCalledWith({ demoEmail: null });
+  });
+
+  it('不正な demoEmail で 400', async () => {
+    const res = await request(app)
+      .put('/v1/users/me')
+      .send({ demoEmail: 'not-an-email' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_REQUEST');
+  });
+
   it('エラー時は 500', async () => {
     mockDocUpdate.mockRejectedValueOnce(new Error('Firestore error'));
     const res = await request(app)

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -4,7 +4,11 @@
 //       Firestore 書き込みに失敗するとユーザー登録自体が拒否されるリスクがある。
 import { Router } from 'express';
 import * as admin from 'firebase-admin';
+import { z } from 'zod';
 import { verifyToken, AuthenticatedRequest } from './middleware/auth';
+
+// demoEmail のバリデーションスキーマ
+const demoEmailSchema = z.string().email().max(254);
 
 export const usersRouter = Router();
 const db = () => admin.firestore();
@@ -58,6 +62,19 @@ usersRouter.put('/me', verifyToken, async (req, res) => {
       return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: 'notifyMethod must be push or email.' } });
     }
     updates.notifyMethod = notifyMethod;
+  }
+  // デモユーザー用メールアドレス更新（XSS サニタイズ: zod でメール形式バリデーション）
+  const { demoEmail } = req.body;
+  if (demoEmail !== undefined) {
+    if (demoEmail === null) {
+      updates.demoEmail = null;
+    } else {
+      const result = demoEmailSchema.safeParse(demoEmail);
+      if (!result.success) {
+        return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: 'demoEmail must be a valid email address.' } });
+      }
+      updates.demoEmail = result.data;
+    }
   }
   if (Object.keys(updates).length === 0) {
     return res.status(400).json({ error: { code: 'INVALID_REQUEST', message: 'No valid fields.' } });

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2020"
+    "target": "es2020",
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": ["src"],


### PR DESCRIPTION
## 概要
デモ機能のバックエンド（Functions）実装。

## 変更内容
- **POST /v1/demo/setup**: 匿名認証→モックデータ投入（users, medications 3件, intakes 3日分, dailyCounts）
- **cleanupDemoUsers**: Scheduled Function（1時間おき）で期限切れデモユーザー自動削除
- **notify.ts**: デモユーザーの demoEmail 優先使用
- **users.ts**: demoEmail 更新時の zod バリデーション
- **firestore.indexes.json**: (isDemo, demoExpiresAt) インデックス追加
- テスト19件追加（全146件合格）

ref #20