### PR TITLE
feat(demo): デモ機能フロントエンド UI 実装（#20）

### DIFF
--- a/src/api/demo.ts
+++ b/src/api/demo.ts
@@ -1,0 +1,5 @@
+// デモ機能 API クライアント
+import { apiFetch } from '../lib/api';
+
+export const setupDemo = () =>
+  apiFetch<void>('/v1/demo/setup', { method: 'POST' });

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -8,11 +8,18 @@ export interface UserProfile {
   notificationToken?: string;
   notifyMethod?: 'push' | 'email';
   adFree: boolean;
+  isDemo?: boolean;
+  demoExpiresAt?: { _seconds: number; _nanoseconds: number };
+  demoEmail?: string | null;
 }
 
 export const getMe = () => apiFetch<UserProfile>('/v1/users/me');
 
-export const updateMe = (data: { language?: 'ja' | 'en' | 'id'; notifyMethod?: 'push' | 'email' }) =>
+export const updateMe = (data: {
+  language?: 'ja' | 'en' | 'id';
+  notifyMethod?: 'push' | 'email';
+  demoEmail?: string;
+}) =>
   apiFetch<UserProfile>('/v1/users/me', {
     method: 'PUT',
     body: JSON.stringify(data),

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+// デモセットアップページ: 匿名認証 → データ投入 → リダイレクト
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { auth } from '@/lib/firebase';
+import { onAuthStateChanged } from 'firebase/auth';
+import { signInAnonymously } from '@/lib/auth';
+import { setupDemo } from '@/api/demo';
+import { getLang, t } from '@/i18n/index';
+
+export default function DemoPage() {
+  const lang = getLang();
+  const router = useRouter();
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (cancelled) return;
+
+      // 既に認証済み（通常ユーザー）ならホームへ
+      if (user && !user.isAnonymous) {
+        router.push('/');
+        return;
+      }
+
+      try {
+        // 匿名認証
+        if (!user) {
+          await signInAnonymously();
+          // onAuthStateChanged が再発火するので、ここでは何もしない
+          return;
+        }
+
+        // 匿名ユーザーでログイン済み → デモデータ投入
+        await setupDemo();
+        if (!cancelled) router.push('/');
+      } catch {
+        if (!cancelled) setError(t('demo.setupError' as any, lang));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, [router, lang]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="text-center space-y-4">
+        {error ? (
+          <>
+            <p className="text-sm text-amber-700 bg-amber-50 rounded-lg p-4">{error}</p>
+            <a
+              href="/"
+              className="inline-block text-sm text-amber-500 hover:text-amber-600 transition"
+            >
+              {t('demo.backToHome' as any, lang)}
+            </a>
+          </>
+        ) : (
+          <>
+            {/* ローディングスピナー */}
+            <div className="w-10 h-10 border-4 border-amber-200 border-t-amber-400 rounded-full animate-spin mx-auto" />
+            <p className="text-gray-500 text-sm">{t('demo.settingUp' as any, lang)}</p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -3,11 +3,13 @@ import React, { useState, useEffect, type ReactNode } from 'react';
 import TabNav from './TabNav';
 import SideNav from './SideNav';
 import AdBanner from './AdBanner';
+import DemoBanner from './DemoBanner';
 import { auth } from '../lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import { listMedications } from '../api/medications';
 import { listIntakesByDate } from '../api/intakes';
 import { getMe } from '../api/users';
+import type { UserProfile } from '../api/users';
 
 interface AppLayoutProps {
   active: 'home' | 'medications' | 'logs' | 'settings';
@@ -20,6 +22,7 @@ export default function AppLayout({ active, children }: AppLayoutProps) {
     id: string; name: string; limitPerDay: number; todayTotal: number;
   }>>([]);
   const [adFree, setAdFree] = useState(false);
+  const [userData, setUserData] = useState<UserProfile | null>(null);
 
   // matchMedia でレスポンシブ検知
   useEffect(() => {
@@ -30,13 +33,16 @@ export default function AppLayout({ active, children }: AppLayoutProps) {
     return () => mq.removeEventListener('change', handler);
   }, []);
 
-  // adFree フラグ取得
+  // adFree フラグ + デモ判定取得
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, async (user) => {
       if (!user) return;
       try {
         const profile = await getMe();
-        if (profile) setAdFree(profile.adFree ?? false);
+        if (profile) {
+          setAdFree(profile.adFree ?? false);
+          setUserData(profile);
+        }
       } catch { /* 取得失敗時は広告表示 */ }
     });
     return () => unsub();
@@ -67,6 +73,12 @@ export default function AppLayout({ active, children }: AppLayoutProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {userData?.isDemo && userData.demoExpiresAt && (
+        <DemoBanner
+          expiresAtSeconds={userData.demoExpiresAt._seconds}
+          isPC={isPC}
+        />
+      )}
       {isPC && <SideNav active={active} medSummaries={medSummaries} adFree={adFree} />}
       <main className={`${isPC ? 'ml-56' : ''} ${!isPC && !adFree ? 'pb-32' : !isPC ? 'pb-20' : 'pb-4'}`}>
         <div className="max-w-2xl mx-auto px-4 pt-4">

--- a/src/components/DemoBanner.tsx
+++ b/src/components/DemoBanner.tsx
@@ -1,0 +1,56 @@
+// デモバナー: 24時間限定デモの残り時間とアカウント作成導線
+import { useState, useEffect } from 'react';
+import { getLang, t } from '../i18n/index';
+
+interface DemoBannerProps {
+  expiresAtSeconds: number;
+  isPC: boolean;
+}
+
+// 残り時間を「○時間○分」形式でフォーマット
+function formatRemaining(seconds: number, lang: string): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (lang === 'ja') return `${hours}時間${minutes}分`;
+  if (lang === 'id') return `${hours} jam ${minutes} menit`;
+  return `${hours}h ${minutes}m`;
+}
+
+export default function DemoBanner({ expiresAtSeconds, isPC }: DemoBannerProps) {
+  const lang = getLang();
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    Math.max(0, expiresAtSeconds - Math.floor(Date.now() / 1000))
+  );
+
+  // 1分ごとに残り時間を更新
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const remaining = Math.max(0, expiresAtSeconds - Math.floor(Date.now() / 1000));
+      setRemainingSeconds(remaining);
+    }, 60_000);
+    return () => clearInterval(timer);
+  }, [expiresAtSeconds]);
+
+  const timeText = formatRemaining(remainingSeconds, lang);
+  const remainingLabel = (t('demo.bannerRemaining' as any, lang) as string).replace('{time}', timeText);
+
+  return (
+    <div
+      className={`bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-sm ${isPC ? 'ml-56' : ''}`}
+      style={{ zIndex: 60 }}
+    >
+      <span className="text-amber-700 font-medium">
+        {t('demo.banner' as any, lang)}
+      </span>
+      <span className="text-amber-600 mx-2">·</span>
+      <span className="text-amber-600">{remainingLabel}</span>
+      <span className="text-amber-600 mx-2">·</span>
+      <a
+        href="/login"
+        className="text-amber-500 hover:text-amber-600 underline transition"
+      >
+        {t('demo.bannerSignUp' as any, lang)}
+      </a>
+    </div>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -21,10 +21,16 @@ export default function LandingPage() {
         <p className="text-gray-500 mb-8">
           {t('lp.hero.subtitle' as any, lang)}
         </p>
-        <a href="/login"
-          className="inline-block bg-amber-400 hover:bg-amber-500 text-white px-8 py-3 rounded-xl text-lg font-medium shadow-lg shadow-amber-200 transition">
-          {t('lp.hero.cta' as any, lang)}
-        </a>
+        <div className="flex flex-col items-center gap-3">
+          <a href="/login"
+            className="inline-block bg-amber-400 hover:bg-amber-500 text-white px-8 py-3 rounded-xl text-lg font-medium shadow-lg shadow-amber-200 transition">
+            {t('lp.hero.cta' as any, lang)}
+          </a>
+          <a href="/demo"
+            className="inline-block text-amber-500 hover:text-amber-600 text-sm underline transition">
+            {t('lp.hero.demo' as any, lang)}
+          </a>
+        </div>
       </section>
 
       {/* 特徴3カード */}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -18,6 +18,10 @@ export default function SettingsPage() {
   const [notifyMethod, setNotifyMethod] = useState<'push' | 'email'>('push');
   const [userEmail, setUserEmail] = useState('');
   const [methodLoading, setMethodLoading] = useState(false);
+  const [isDemo, setIsDemo] = useState(false);
+  const [demoEmail, setDemoEmail] = useState('');
+  const [demoEmailSaving, setDemoEmailSaving] = useState(false);
+  const [demoEmailSaved, setDemoEmailSaved] = useState(false);
 
   useEffect(() => {
     if ('Notification' in window) {
@@ -29,6 +33,8 @@ export default function SettingsPage() {
     getMe().then(user => {
       setNotifyMethod(user.notifyMethod ?? 'push');
       setUserEmail(user.email);
+      setIsDemo(user.isDemo ?? false);
+      if (user.demoEmail) setDemoEmail(user.demoEmail);
     }).catch(() => {});
   }, []);
 
@@ -69,6 +75,21 @@ export default function SettingsPage() {
       setError(t('errors.internal', lang));
     } finally {
       setMethodLoading(false);
+    }
+  }
+
+  // デモ用メールアドレス保存
+  async function handleDemoEmailSave() {
+    setDemoEmailSaving(true);
+    setDemoEmailSaved(false);
+    try {
+      await updateMe({ demoEmail });
+      setDemoEmailSaved(true);
+      setTimeout(() => setDemoEmailSaved(false), 2000);
+    } catch {
+      setError(t('errors.internal', lang));
+    } finally {
+      setDemoEmailSaving(false);
     }
   }
 
@@ -177,10 +198,37 @@ export default function SettingsPage() {
         )}
 
         {/* メール通知: 送信先表示 */}
-        {notifyMethod === 'email' && userEmail && (
+        {notifyMethod === 'email' && !isDemo && userEmail && (
           <p className="text-xs text-gray-500">
             {(t('settings.notifyEmailTo' as any, lang) as string).replace('{email}', userEmail)}
           </p>
+        )}
+
+        {/* デモ用メールアドレス入力 */}
+        {notifyMethod === 'email' && isDemo && (
+          <div className="space-y-2">
+            <label className="text-xs text-gray-500">
+              {t('settings.demoEmail' as any, lang)}
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="email"
+                value={demoEmail}
+                onChange={e => setDemoEmail(e.target.value)}
+                placeholder={t('settings.demoEmailPlaceholder' as any, lang)}
+                className="flex-1 text-sm border rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-300"
+              />
+              <button
+                onClick={handleDemoEmailSave}
+                disabled={demoEmailSaving || !demoEmail}
+                className="text-sm bg-amber-400 hover:bg-amber-500 text-white px-4 py-2 rounded-lg transition disabled:opacity-50"
+              >
+                {demoEmailSaved
+                  ? t('settings.demoEmailSaved' as any, lang)
+                  : t('settings.demoEmailSave' as any, lang)}
+              </button>
+            </div>
+          </div>
         )}
 
         {notifyError && (
@@ -190,13 +238,15 @@ export default function SettingsPage() {
         )}
       </section>
 
-      {/* データエクスポート */}
-      <button
-        onClick={handleExport}
-        className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-2 rounded-lg transition text-sm"
-      >
-        {t('settings.exportData' as any, lang)}
-      </button>
+      {/* データエクスポート（デモ時は非表示） */}
+      {!isDemo && (
+        <button
+          onClick={handleExport}
+          className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-2 rounded-lg transition text-sm"
+        >
+          {t('settings.exportData' as any, lang)}
+        </button>
+      )}
 
       {/* ログアウト */}
       <button
@@ -206,42 +256,44 @@ export default function SettingsPage() {
         {t('settings.logout' as any, lang)}
       </button>
 
-      {/* アカウント削除 */}
-      <section className="border-t pt-6">
-        <h2 className="text-sm font-medium text-gray-500 mb-3">
-          {t('settings.dangerZone' as any, lang)}
-        </h2>
-        {!confirmDelete ? (
-          <button
-            onClick={() => setConfirmDelete(true)}
-            className="w-full bg-gray-100 hover:bg-gray-200 text-gray-600 py-2 rounded-lg transition text-sm"
-          >
-            {t('settings.deleteAccount' as any, lang)}
-          </button>
-        ) : (
-          <div className="bg-gray-50 rounded-xl p-4 space-y-3">
-            <p className="text-sm text-gray-600">
-              {t('settings.deleteConfirm' as any, lang)}
-            </p>
-            {error && <p className="text-sm text-amber-700 bg-amber-50 rounded p-2">{error}</p>}
-            <div className="flex gap-2">
-              <button
-                onClick={handleDeleteAccount}
-                disabled={deleting}
-                className="flex-1 bg-gray-400 hover:bg-gray-500 text-white py-2 rounded-lg transition text-sm disabled:opacity-50"
-              >
-                {deleting ? t('common.loading', lang) : t('settings.deleteConfirmYes' as any, lang)}
-              </button>
-              <button
-                onClick={() => setConfirmDelete(false)}
-                className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 py-2 rounded-lg transition text-sm"
-              >
-                {t('common.cancel', lang)}
-              </button>
+      {/* アカウント削除（デモ時は非表示） */}
+      {!isDemo && (
+        <section className="border-t pt-6">
+          <h2 className="text-sm font-medium text-gray-500 mb-3">
+            {t('settings.dangerZone' as any, lang)}
+          </h2>
+          {!confirmDelete ? (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              className="w-full bg-gray-100 hover:bg-gray-200 text-gray-600 py-2 rounded-lg transition text-sm"
+            >
+              {t('settings.deleteAccount' as any, lang)}
+            </button>
+          ) : (
+            <div className="bg-gray-50 rounded-xl p-4 space-y-3">
+              <p className="text-sm text-gray-600">
+                {t('settings.deleteConfirm' as any, lang)}
+              </p>
+              {error && <p className="text-sm text-amber-700 bg-amber-50 rounded p-2">{error}</p>}
+              <div className="flex gap-2">
+                <button
+                  onClick={handleDeleteAccount}
+                  disabled={deleting}
+                  className="flex-1 bg-gray-400 hover:bg-gray-500 text-white py-2 rounded-lg transition text-sm disabled:opacity-50"
+                >
+                  {deleting ? t('common.loading', lang) : t('settings.deleteConfirmYes' as any, lang)}
+                </button>
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-600 py-2 rounded-lg transition text-sm"
+                >
+                  {t('common.cancel', lang)}
+                </button>
+              </div>
             </div>
-          </div>
-        )}
-      </section>
+          )}
+        </section>
+      )}
 
       {/* フッターリンク */}
       <section className="border-t pt-4 text-center text-xs text-gray-400 space-x-4">

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -133,5 +133,16 @@
   "settings.notifyMethod": "Notification method",
   "settings.notifyMethodPush": "Push notification",
   "settings.notifyMethodEmail": "Email",
-  "settings.notifyEmailTo": "Sends to {email}"
+  "settings.notifyEmailTo": "Sends to {email}",
+  "settings.demoEmail": "Email for notifications",
+  "settings.demoEmailPlaceholder": "example@mail.com",
+  "settings.demoEmailSave": "Save",
+  "settings.demoEmailSaved": "Saved",
+  "demo.settingUp": "Setting up your demo...",
+  "demo.setupError": "Failed to set up demo. Please try again.",
+  "demo.backToHome": "Back to home",
+  "demo.banner": "24-hour demo",
+  "demo.bannerRemaining": "{time} remaining",
+  "demo.bannerSignUp": "Create an account",
+  "lp.hero.demo": "Try the demo"
 }

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -133,5 +133,16 @@
   "settings.notifyMethod": "Metode notifikasi",
   "settings.notifyMethodPush": "Notifikasi push",
   "settings.notifyMethodEmail": "Email",
-  "settings.notifyEmailTo": "Dikirim ke {email}"
+  "settings.notifyEmailTo": "Dikirim ke {email}",
+  "settings.demoEmail": "Email untuk notifikasi",
+  "settings.demoEmailPlaceholder": "example@mail.com",
+  "settings.demoEmailSave": "Simpan",
+  "settings.demoEmailSaved": "Tersimpan",
+  "demo.settingUp": "Menyiapkan demo...",
+  "demo.setupError": "Gagal menyiapkan demo. Coba lagi.",
+  "demo.backToHome": "Kembali ke beranda",
+  "demo.banner": "Demo 24 jam",
+  "demo.bannerRemaining": "Sisa {time}",
+  "demo.bannerSignUp": "Buat akun",
+  "lp.hero.demo": "Coba demo"
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -133,5 +133,16 @@
   "settings.notifyMethod": "通知方法",
   "settings.notifyMethodPush": "プッシュ通知",
   "settings.notifyMethodEmail": "メール",
-  "settings.notifyEmailTo": "{email} に送信します"
+  "settings.notifyEmailTo": "{email} に送信します",
+  "settings.demoEmail": "通知用メールアドレス",
+  "settings.demoEmailPlaceholder": "example@mail.com",
+  "settings.demoEmailSave": "保存",
+  "settings.demoEmailSaved": "保存しました",
+  "demo.settingUp": "デモを準備しています...",
+  "demo.setupError": "デモの準備に失敗しました。もう一度お試しください。",
+  "demo.backToHome": "ホームに戻る",
+  "demo.banner": "24時間限定デモ",
+  "demo.bannerRemaining": "残り {time}",
+  "demo.bannerSignUp": "アカウントを作成する",
+  "lp.hero.demo": "デモを試す"
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import {
   sendPasswordResetEmail,
   onAuthStateChanged,
   signInWithPopup,
+  signInAnonymously as firebaseSignInAnonymously,
   GoogleAuthProvider,
   type User,
 } from 'firebase/auth';
@@ -42,5 +43,11 @@ export function getCurrentUser(): Promise<User | null> {
 export async function signInWithGoogle(): Promise<User> {
   const provider = new GoogleAuthProvider();
   const result = await signInWithPopup(auth, provider);
+  return result.user;
+}
+
+// 匿名認証（デモ用）
+export async function signInAnonymously(): Promise<User> {
+  const result = await firebaseSignInAnonymously(auth);
   return result.user;
 }


### PR DESCRIPTION
## 概要
デモ機能のフロントエンド UI 実装。

## 変更内容
- **/demo ページ**: 匿名認証→セットアップ→リダイレクト（ローディング付き）
- **DemoBanner**: 24時間限定表示 + 残り時間 + アカウント作成導線
- **SettingsPage**: デモ時の機能制限（削除・エクスポート非表示）+ demoEmail 入力
- **LandingPage**: 「デモを試す」ボタン追加
- **i18n**: デモ関連テキスト12キーを3言語（ja/en/id）追加

ref #20