### PR TITLE
feat: メール通知のみ化 + バージョン管理 + 更新履歴（v1.0.0）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,102 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test -- --coverage
+
+  # バージョン自動バンプ + CHANGELOG生成（main push 時のみ）
+  version-bump:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [frontend, functions]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: version-bump
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: バージョンバンプ判定 + 実行
+        id: bump
+        run: |
+          # 最新タグからのコミットを解析
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LATEST_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${LATEST_TAG}..HEAD"
+          fi
+
+          # README.md のみの変更かチェック
+          if [ -n "$LATEST_TAG" ]; then
+            CHANGED_FILES=$(git diff --name-only "$LATEST_TAG" HEAD)
+            NON_README=$(echo "$CHANGED_FILES" | grep -v '^README.md$' || true)
+            if [ -z "$NON_README" ]; then
+              echo "skip=true" >> $GITHUB_OUTPUT
+              echo "README.md のみの変更のためスキップ"
+              exit 0
+            fi
+          fi
+
+          # コミットメッセージ解析
+          COMMITS=$(git log --pretty=format:"%s" $RANGE 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # CI自動コミットはスキップ
+          COMMITS=$(echo "$COMMITS" | grep -v '^\[skip ci\]' || true)
+          if [ -z "$COMMITS" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BUMP_TYPE=""
+          # BREAKING CHANGE 検出（major）
+          if echo "$COMMITS" | grep -qE '^(feat|fix|update)!|BREAKING CHANGE:'; then
+            BUMP_TYPE="major"
+          # feat 検出（minor）
+          elif echo "$COMMITS" | grep -qE '^feat(\(|:)'; then
+            BUMP_TYPE="minor"
+          # fix/update 検出（patch）
+          elif echo "$COMMITS" | grep -qE '^(fix|update)(\(|:)'; then
+            BUMP_TYPE="patch"
+          fi
+
+          if [ -z "$BUMP_TYPE" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "バンプ対象のコミットなし"
+            exit 0
+          fi
+
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+
+      - name: バージョンバンプ実行
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git pull --rebase
+          npm version ${{ steps.bump.outputs.bump_type }} -m "[skip ci] chore(release): v%s"
+
+      - name: CHANGELOG 生成
+        if: steps.bump.outputs.skip != 'true'
+        run: npx conventional-changelog -p angular -i CHANGELOG.md -s
+
+      - name: CHANGELOG コミット + push
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git add CHANGELOG.md
+          git commit -m "[skip ci] docs: CHANGELOG.md を更新" || true
+          git push --follow-tags

--- a/functions/src/notify.ts
+++ b/functions/src/notify.ts
@@ -80,6 +80,11 @@ export const sendMedicationReminders = onSchedule(
           await sendEmail(email, 'ObatLog リマインダー', html);
           totalSent++;
         } else {
+          // キルスイッチ: 環境変数で push 配送を制御
+          if (process.env.BACKEND_PUSH_DELIVERY_ENABLED !== 'true') {
+            console.info('[sendMedicationReminders] push delivery disabled by kill switch', { userId });
+            continue;
+          }
           // FCM プッシュ通知（既存ロジック）
           const token = userData?.notificationToken;
           if (!token) {

--- a/functions/src/tests/notify.test.ts
+++ b/functions/src/tests/notify.test.ts
@@ -66,6 +66,7 @@ afterAll(() => jest.restoreAllMocks());
 beforeEach(() => {
   jest.clearAllMocks();
   medsQueryGet.mockResolvedValue({ empty: true, size: 0, docs: [] });
+  delete process.env.BACKEND_PUSH_DELIVERY_ENABLED;
 });
 
 describe('sendMedicationReminders', () => {
@@ -76,6 +77,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('プッシュ通知を送信する', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false,
       size: 1,
@@ -96,6 +98,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('notifyMethod 未設定はプッシュ通知として扱う', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 1,
       docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬A', limitPerDay: 3 }) }],
@@ -111,6 +114,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('FCMトークンがない場合はスキップ', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 1,
       docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬A', limitPerDay: 3 }) }],
@@ -125,6 +129,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('FCM送信エラーでも処理を継続する', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 1,
       docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬A', limitPerDay: 3 }) }],
@@ -216,6 +221,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('カウンターに total がない場合 0 にフォールバック', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 1,
       docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬X', limitPerDay: 3 }) }],
@@ -249,6 +255,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('複数ユーザー・複数薬を正しくグループ化する', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 3,
       docs: [
@@ -269,6 +276,7 @@ describe('sendMedicationReminders', () => {
   });
 
   it('ユーザー単位のエラーが他ユーザーに影響しない', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
     medsQueryGet.mockResolvedValue({
       empty: false, size: 2,
       docs: [
@@ -286,5 +294,36 @@ describe('sendMedicationReminders', () => {
     await handler();
     // u1 はエラーで失敗、u2 は正常に送信
     expect(messagingSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('BACKEND_PUSH_DELIVERY_ENABLED=false のときpush送信をスキップする', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'false';
+    medsQueryGet.mockResolvedValue({
+      empty: false, size: 1,
+      docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬A', limitPerDay: 3 }) }],
+    });
+    userDocGet.mockResolvedValue({
+      data: () => ({ notifyMethod: 'push', notificationToken: 'token' }),
+    });
+    counterDocGet.mockResolvedValue({ exists: false });
+
+    await handler();
+    expect(messagingSend).not.toHaveBeenCalled();
+  });
+
+  it('BACKEND_PUSH_DELIVERY_ENABLED=true のときpush送信する', async () => {
+    process.env.BACKEND_PUSH_DELIVERY_ENABLED = 'true';
+    medsQueryGet.mockResolvedValue({
+      empty: false, size: 1,
+      docs: [{ id: 'med-1', data: () => ({ userId: 'u1', name: '薬A', limitPerDay: 3 }) }],
+    });
+    userDocGet.mockResolvedValue({
+      data: () => ({ notifyMethod: 'push', notificationToken: 'token' }),
+    });
+    counterDocGet.mockResolvedValue({ exists: false });
+    messagingSend.mockResolvedValue('ok');
+
+    await handler();
+    expect(messagingSend).toHaveBeenCalled();
   });
 });

--- a/functions/src/tests/users.test.ts
+++ b/functions/src/tests/users.test.ts
@@ -53,7 +53,7 @@ beforeAll(() => {
 
 beforeEach(() => jest.clearAllMocks());
 
-const userData = { email: 'test@test.com', language: 'ja', notificationToken: null, adFree: false, notifyMethod: 'push' };
+const userData = { email: 'test@test.com', language: 'ja', notificationToken: null, adFree: false, notifyMethod: 'email' };
 
 describe('GET /v1/users/me', () => {
   it('既存ユーザーのプロフィールを返す', async () => {
@@ -76,7 +76,7 @@ describe('GET /v1/users/me', () => {
     expect(mockDocSet).toHaveBeenCalledWith(expect.objectContaining({
       email: 'test@test.com',
       language: 'ja',
-      notifyMethod: 'push',
+      notifyMethod: 'email',
     }));
   });
 

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -24,7 +24,7 @@ async function ensureUserDoc(uid: string, email: string): Promise<void> {
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       notificationToken: null,
       adFree: false,
-      notifyMethod: 'push',
+      notifyMethod: 'email',
     });
   }
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,7 @@
 import withSerwistInit from '@serwist/next';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 const withSerwist = withSerwistInit({
   swSrc: 'src/app/sw.ts',
@@ -10,6 +13,9 @@ const withSerwist = withSerwistInit({
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
 };
 
 export default withSerwist(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obatlog",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obatlog",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@serwist/next": "^9.5.7",
         "firebase": "^11.4.0",
@@ -27,6 +27,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "autoprefixer": "^10.4.27",
+        "conventional-changelog-cli": "^5.0.0",
         "happy-dom": "^20.8.8",
         "husky": "^9.1.7",
         "typescript": "^5.7.3",
@@ -1043,6 +1044,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hutson/parse-repository-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
+      "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@img/colour": {
@@ -2418,6 +2429,13 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2581,6 +2599,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/add-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -3028,6 +3053,29 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/conventional-changelog": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
+      "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-atom": "^5.0.0",
+        "conventional-changelog-codemirror": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-core": "^8.0.0",
+        "conventional-changelog-ember": "^5.0.0",
+        "conventional-changelog-eslint": "^6.0.0",
+        "conventional-changelog-express": "^5.0.0",
+        "conventional-changelog-jquery": "^6.0.0",
+        "conventional-changelog-jshint": "^5.0.0",
+        "conventional-changelog-preset-loader": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
@@ -3041,6 +3089,46 @@
         "node": ">=18"
       }
     },
+    "node_modules/conventional-changelog-atom": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.1.0.tgz",
+      "integrity": "sha512-fw7GpI9jHNCWGBnTsPRI452ypQbNupGwsjrXfozvRNE0c92pJRpoj9rXfzDKUYJcsmk0H4XKaQjhjelwI9z27w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
+      "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+      "deprecated": "This package is no longer maintained. Please use the conventional-changelog package instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "add-stream": "^1.0.0",
+        "conventional-changelog": "^6.0.0",
+        "meow": "^13.0.0",
+        "tempfile": "^5.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-codemirror": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.1.0.tgz",
+      "integrity": "sha512-iXhy63YczB+yWA9DrsYbquSYLvWKsK9M3WC+xQPEm8cOn4oXzKpmTp2uH3qi7+i10oTcGJTvq9lsBpZmMADaNg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/conventional-changelog-conventionalcommits": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.0.tgz",
@@ -3050,6 +3138,134 @@
       "dependencies": {
         "compare-func": "^2.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-core": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
+      "integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hutson/parse-repository-url": "^5.0.0",
+        "add-stream": "^1.0.0",
+        "conventional-changelog-writer": "^8.0.0",
+        "conventional-commits-parser": "^6.0.0",
+        "git-raw-commits": "^5.0.0",
+        "git-semver-tags": "^8.0.0",
+        "hosted-git-info": "^7.0.0",
+        "normalize-package-data": "^6.0.0",
+        "read-package-up": "^11.0.0",
+        "read-pkg": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-ember": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.1.0.tgz",
+      "integrity": "sha512-XNcgGcdJt7wh341BBML0CI8DKpqE5lKD1WahzFHGZFvKTzJr1rZW976cw7beqKLOBbzdrH9ZIkE/s2TfbOuM3g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-eslint": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.1.0.tgz",
+      "integrity": "sha512-beWr3qzuEMN9gznMWa8PhTVfGkGXoq+XnUzViNXg5KygrgV728ZRqZngz3uPhz5+ayUhPrpNFYqIE0qHWz9NAw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.1.0.tgz",
+      "integrity": "sha512-g/s9eLohrefYTSNQaB6+k0ONbiVx41YOKBbIOIM3ST/NtedAgppCJnrpKXVN9sOmpPkN4vjFwURlfvpEDUjoeg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jquery": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.1.0.tgz",
+      "integrity": "sha512-/sFhULybhFrMg+qc8MHHHSj7kTVMfx5C7rSM6Z9EjduVoAQJdGRq/wpv/SWPMQ+KPNSYHqDLwm/x2Z5hOcYvqQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-jshint": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.2.0.tgz",
+      "integrity": "sha512-OaatyvHXP1fjI7Mx0b1IkmhbhTsVHsytnsQSkOj4rhGbFMoTcfvbwm/vAtCzRMXOxojK1EDMBBmBj1pM9KNy/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -3403,6 +3619,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/firebase": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
@@ -3542,6 +3771,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/git-semver-tags": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
+      "integrity": "sha512-zMbamckSNdlT4U48IMFa2Cn6FTzM+2yF6/gEmStPJI8PiLxd/bT6dw10+mc6u5Qe4fhrc/y9nU290FWjQhAV7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-semver-tags": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -3591,6 +3837,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/happy-dom": {
       "version": "20.8.8",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.8.tgz",
@@ -3619,6 +3897,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/http-parser-js": {
@@ -3695,6 +3986,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ini": {
@@ -4363,6 +4667,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/next": {
       "version": "16.2.1",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
@@ -4449,6 +4760,21 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4944,6 +5270,62 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5270,6 +5652,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5499,6 +5917,32 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/tempfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
+      "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "temp-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5596,6 +6040,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5610,11 +6067,38 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5651,6 +6135,17 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.2",
@@ -5899,6 +6394,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obatlog",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "engines": {
     "node": ">=18.17.1"
   },
@@ -33,6 +33,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "autoprefixer": "^10.4.27",
+    "conventional-changelog-cli": "^5.0.0",
     "happy-dom": "^20.8.8",
     "husky": "^9.1.7",
     "typescript": "^5.7.3",

--- a/scripts/migrate-push-to-email.ts
+++ b/scripts/migrate-push-to-email.ts
@@ -1,0 +1,49 @@
+// 既存ユーザーの notifyMethod を push → email に一括移行するワンショットスクリプト
+// 実行: npx ts-node scripts/migrate-push-to-email.ts
+//
+// 前提:
+// - GOOGLE_APPLICATION_CREDENTIALS が設定されていること
+// - または Firebase Admin SDK のデフォルト認証情報が利用可能なこと
+
+import * as admin from 'firebase-admin';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+async function migrate() {
+  const usersSnap = await db.collection('users')
+    .where('notifyMethod', '==', 'push')
+    .get();
+
+  if (usersSnap.empty) {
+    console.log('移行対象のユーザーはいません');
+    return;
+  }
+
+  console.log(`移行対象: ${usersSnap.size} ユーザー`);
+
+  // Firestore のバッチは最大500件
+  const batchSize = 500;
+  const docs = usersSnap.docs;
+  let migrated = 0;
+
+  for (let i = 0; i < docs.length; i += batchSize) {
+    const batch = db.batch();
+    const chunk = docs.slice(i, i + batchSize);
+
+    for (const doc of chunk) {
+      batch.update(doc.ref, { notifyMethod: 'email' });
+    }
+
+    await batch.commit();
+    migrated += chunk.length;
+    console.log(`${migrated} / ${docs.length} ユーザーを移行しました`);
+  }
+
+  console.log(`移行完了: ${migrated} ユーザー`);
+}
+
+migrate().catch(err => {
+  console.error('移行エラー:', err);
+  process.exit(1);
+});

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ChangelogPage from '../../components/ChangelogPage';
+
+export default function Page() {
+  return <ChangelogPage />;
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -4,6 +4,7 @@ import TabNav from './TabNav';
 import SideNav from './SideNav';
 import AdBanner from './AdBanner';
 import DemoBanner from './DemoBanner';
+import UpdateModal from './UpdateModal';
 import { auth } from '../lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import { listMedications } from '../api/medications';
@@ -73,6 +74,7 @@ export default function AppLayout({ active, children }: AppLayoutProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <UpdateModal isDemo={userData?.isDemo ?? false} />
       {userData?.isDemo && userData.demoExpiresAt && (
         <DemoBanner
           expiresAtSeconds={userData.demoExpiresAt._seconds}

--- a/src/components/ChangelogPage.tsx
+++ b/src/components/ChangelogPage.tsx
@@ -1,0 +1,55 @@
+// 更新履歴ページ: releases.json をバージョン降順で表示
+'use client';
+
+import { getLang, t } from '../i18n/index';
+import releases from '../i18n/releases.json';
+
+type ReleaseEntry = { date: string; changes: Record<string, string[]> };
+const typedReleases = releases as Record<string, ReleaseEntry>;
+
+// セマンティックバージョンを降順ソート
+function sortVersionsDesc(versions: string[]): string[] {
+  return versions.sort((a, b) => {
+    const pa = a.split('.').map(Number);
+    const pb = b.split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+      if (pa[i] !== pb[i]) return pb[i] - pa[i];
+    }
+    return 0;
+  });
+}
+
+export default function ChangelogPage() {
+  const lang = getLang();
+  const versions = sortVersionsDesc(Object.keys(typedReleases));
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-6">
+      <a href="/settings" className="text-sm text-gray-400 hover:text-gray-600">
+        {t('legal.back' as any, lang)}
+      </a>
+      <h1 className="text-xl font-bold text-gray-800">
+        {t('changelog.title' as any, lang)}
+      </h1>
+
+      {versions.map(version => {
+        const entry = typedReleases[version];
+        const changes = entry.changes[lang] ?? entry.changes['en'] ?? entry.changes['ja'] ?? [];
+
+        return (
+          <section key={version} className="bg-white border rounded-lg px-4 py-3 space-y-2">
+            <div className="flex justify-between items-center">
+              <h2 className="text-sm font-bold text-gray-800">v{version}</h2>
+              <span className="text-xs text-gray-400">{entry.date}</span>
+            </div>
+            <ul className="text-sm text-gray-600 list-disc pl-5 space-y-1">
+              {changes.map((change, i) => (
+                <li key={i}>{change}</li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -146,66 +146,19 @@ export default function SettingsPage() {
         <span className="text-gray-800 font-medium">{langLabel}</span>
       </button>
 
-      {/* 通知 */}
+      {/* 通知（メール通知のみ表示。push通知UIは将来LINE/Androidネイティブ追加時に復活予定） */}
       <section className="bg-white border rounded-lg px-4 py-3 space-y-3">
-        {/* 通知方法の選択 */}
-        <div>
-          <span className="text-sm text-gray-600">{t('settings.notifyMethod' as any, lang)}</span>
-          <div className="flex gap-2 mt-2">
-            <button
-              onClick={() => handleNotifyMethodChange('push')}
-              disabled={methodLoading}
-              className={`flex-1 text-sm py-2 rounded-lg transition ${
-                notifyMethod === 'push'
-                  ? 'bg-amber-400 text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              } disabled:opacity-50`}
-            >
-              {t('settings.notifyMethodPush' as any, lang)}
-            </button>
-            <button
-              onClick={() => handleNotifyMethodChange('email')}
-              disabled={methodLoading}
-              className={`flex-1 text-sm py-2 rounded-lg transition ${
-                notifyMethod === 'email'
-                  ? 'bg-amber-400 text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-              } disabled:opacity-50`}
-            >
-              {t('settings.notifyMethodEmail' as any, lang)}
-            </button>
-          </div>
-        </div>
-
-        {/* プッシュ通知: 許可ボタン */}
-        {notifyMethod === 'push' && (
-          <div className="flex justify-between items-center">
-            <span className="text-sm text-gray-600">{t('settings.notifications' as any, lang)}</span>
-            {notifyStatus === 'granted' ? (
-              <span className="text-xs text-green-600 bg-green-50 px-2 py-1 rounded">ON</span>
-            ) : notifyStatus === 'denied' ? (
-              <span className="text-xs text-gray-400">{t('settings.notifyDenied' as any, lang)}</span>
-            ) : (
-              <button
-                onClick={handleEnableNotifications}
-                disabled={notifyLoading}
-                className="text-xs bg-amber-400 hover:bg-amber-500 text-white px-3 py-1 rounded-lg transition disabled:opacity-50"
-              >
-                {notifyLoading ? '...' : t('settings.notifyEnable' as any, lang)}
-              </button>
-            )}
-          </div>
-        )}
+        <span className="text-sm text-gray-600">{t('settings.notifications' as any, lang)}</span>
 
         {/* メール通知: 送信先表示 */}
-        {notifyMethod === 'email' && !isDemo && userEmail && (
+        {!isDemo && userEmail && (
           <p className="text-xs text-gray-500">
             {(t('settings.notifyEmailTo' as any, lang) as string).replace('{email}', userEmail)}
           </p>
         )}
 
         {/* デモ用メールアドレス入力 */}
-        {notifyMethod === 'email' && isDemo && (
+        {isDemo && (
           <div className="space-y-2">
             <label className="text-xs text-gray-500">
               {t('settings.demoEmail' as any, lang)}
@@ -297,6 +250,7 @@ export default function SettingsPage() {
 
       {/* フッターリンク */}
       <section className="border-t pt-4 text-center text-xs text-gray-400 space-x-4">
+        <a href="/changelog" className="hover:text-gray-600">{t('settings.changelog' as any, lang)}</a>
         <a href="/privacy" className="hover:text-gray-600">{t('nav.privacy' as any, lang)}</a>
         <a href="/terms" className="hover:text-gray-600">{t('nav.terms' as any, lang)}</a>
       </section>

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,0 +1,92 @@
+// バージョン更新通知モーダル
+// localStorage の lastSeenVersion と NEXT_PUBLIC_APP_VERSION を比較し、
+// 差分がある場合に更新内容をモーダル表示する。
+import { useState, useEffect } from 'react';
+import { getLang, t } from '../i18n/index';
+import releases from '../i18n/releases.json';
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
+const LS_KEY = 'lastSeenVersion';
+
+interface UpdateModalProps {
+  isDemo: boolean;
+}
+
+export default function UpdateModal({ isDemo }: UpdateModalProps) {
+  const [visible, setVisible] = useState(false);
+  const lang = getLang();
+
+  useEffect(() => {
+    // デモユーザーは表示しない
+    if (isDemo) return;
+
+    try {
+      const lastSeen = localStorage.getItem(LS_KEY);
+      if (!lastSeen) {
+        // 初回利用: モーダルを出さず、現在のバージョンをセットするだけ
+        localStorage.setItem(LS_KEY, APP_VERSION);
+        return;
+      }
+      if (lastSeen !== APP_VERSION) {
+        setVisible(true);
+      }
+    } catch {
+      // localStorage がブロックされている場合は無視
+    }
+  }, [isDemo]);
+
+  function handleClose() {
+    setVisible(false);
+    try {
+      localStorage.setItem(LS_KEY, APP_VERSION);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!visible) return null;
+
+  // releases.json からバージョンの変更点を取得（フォールバック: 汎用文言）
+  const releaseData = (releases as Record<string, { date: string; changes: Record<string, string[]> }>)[APP_VERSION];
+  const changes = releaseData?.changes[lang] ?? releaseData?.changes['en'] ?? null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={handleClose}>
+      <div className="fixed inset-0 bg-black/30" />
+      <div
+        className="relative bg-white rounded-2xl shadow-xl max-w-sm w-full mx-4 p-6 space-y-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-gray-800">
+          {t('update.title' as any, lang)}
+        </h2>
+        <p className="text-sm text-gray-600">
+          {(t('update.message' as any, lang) as string).replace('{version}', APP_VERSION)}
+        </p>
+
+        {changes && (
+          <ul className="text-sm text-gray-600 list-disc pl-5 space-y-1">
+            {changes.map((change, i) => (
+              <li key={i}>{change}</li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex flex-col gap-2 pt-2">
+          <a
+            href="/changelog"
+            className="text-center text-sm text-amber-600 hover:text-amber-700 transition"
+          >
+            {t('update.showChangelog' as any, lang)}
+          </a>
+          <button
+            onClick={handleClose}
+            className="w-full bg-amber-400 hover:bg-amber-500 text-white py-2 rounded-lg transition text-sm"
+          >
+            {t('update.close' as any, lang)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -144,5 +144,11 @@
   "demo.banner": "24-hour demo",
   "demo.bannerRemaining": "{time} remaining",
   "demo.bannerSignUp": "Create an account",
-  "lp.hero.demo": "Try the demo"
+  "lp.hero.demo": "Try the demo",
+  "settings.changelog": "Release Notes",
+  "changelog.title": "Release Notes",
+  "update.title": "App Updated",
+  "update.message": "Updated to version {version}",
+  "update.close": "Close",
+  "update.showChangelog": "View Release Notes"
 }

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -144,5 +144,11 @@
   "demo.banner": "Demo 24 jam",
   "demo.bannerRemaining": "Sisa {time}",
   "demo.bannerSignUp": "Buat akun",
-  "lp.hero.demo": "Coba demo"
+  "lp.hero.demo": "Coba demo",
+  "settings.changelog": "Catatan Rilis",
+  "changelog.title": "Catatan Rilis",
+  "update.title": "Aplikasi Diperbarui",
+  "update.message": "Diperbarui ke versi {version}",
+  "update.close": "Tutup",
+  "update.showChangelog": "Lihat Catatan Rilis"
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -144,5 +144,11 @@
   "demo.banner": "24時間限定デモ",
   "demo.bannerRemaining": "残り {time}",
   "demo.bannerSignUp": "アカウントを作成する",
-  "lp.hero.demo": "デモを試す"
+  "lp.hero.demo": "デモを試す",
+  "settings.changelog": "更新履歴",
+  "changelog.title": "更新履歴",
+  "update.title": "アップデートしました",
+  "update.message": "バージョン {version} に更新されました",
+  "update.close": "閉じる",
+  "update.showChangelog": "更新履歴を見る"
 }

--- a/src/i18n/releases.json
+++ b/src/i18n/releases.json
@@ -1,0 +1,28 @@
+{
+  "1.0.0": {
+    "date": "2026-03-26",
+    "changes": {
+      "ja": [
+        "初回リリース",
+        "服薬記録・過量チェック・通知機能",
+        "デモ機能",
+        "Google ログイン対応",
+        "多言語対応（日本語・英語・インドネシア語）"
+      ],
+      "en": [
+        "Initial release",
+        "Medication tracking, overdose check, notifications",
+        "Demo mode",
+        "Google sign-in support",
+        "Multi-language support (Japanese, English, Indonesian)"
+      ],
+      "id": [
+        "Rilis pertama",
+        "Pencatatan obat, pemeriksaan overdosis, notifikasi",
+        "Mode demo",
+        "Dukungan login Google",
+        "Dukungan multi-bahasa (Jepang, Inggris, Indonesia)"
+      ]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
   ],
   "exclude": [
     "node_modules",
-    "functions"
+    "functions",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## 概要
通知のメール一本化、セマンティックバージョニング導入、更新履歴機能を追加するv1.0.0リリース。

- **通知**: push通知UIを非表示 + サーバ側キルスイッチ + 既存ユーザー移行スクリプト
- **バージョン**: v1.0.0。ビルド時に `NEXT_PUBLIC_APP_VERSION` 注入。更新通知モーダル表示
- **更新履歴**: `/changelog` ページ + `releases.json` で日英インドネシア語表示
- **CI**: mainマージ時にconventional commitsからバージョン自動バンプ + CHANGELOG.md生成

## 変更内容（19ファイル、+919/-61行）

### バックエンド
- `functions/src/notify.ts` — `BACKEND_PUSH_DELIVERY_ENABLED` キルスイッチ
- `functions/src/users.ts` — デフォルト `notifyMethod` を `email` に変更
- `scripts/migrate-push-to-email.ts` — 既存ユーザー一括移行（ページネーション対応）

### フロントエンド
- `src/components/UpdateModal.tsx` — バージョン更新通知モーダル（新規）
- `src/components/ChangelogPage.tsx` — 更新履歴ページ（新規）
- `src/components/SettingsPage.tsx` — push通知UI非表示 + 更新履歴リンク追加
- `src/components/AppLayout.tsx` — UpdateModal 配置
- `next.config.mjs` — バージョン注入
- `package.json` — v1.0.0 + conventional-changelog-cli

### i18n
- `src/i18n/{ja,en,id}.json` — 6キー × 3言語追加
- `src/i18n/releases.json` — v1.0.0 リリースノート

### CI
- `.github/workflows/ci.yml` — version-bump ジョブ（concurrency直列化、BREAKING CHANGE対応）

## テスト結果
- バックエンド: 148テスト全PASS（カバレッジ98%+）
- フロントエンド: 17テスト全PASS
- TypeScript: エラーなし

## ロールアウト手順
1. `BACKEND_PUSH_DELIVERY_ENABLED=false` を Firebase Functions 環境変数に設定
2. このPRをマージ（CI version-bumpが走る）
3. 1日後: `scripts/migrate-push-to-email.ts` で既存ユーザーを一括移行

## テストプラン
- [ ] push通知キルスイッチ動作確認
- [ ] 設定画面でメール通知のみ表示
- [ ] 更新モーダル: 初回非表示、バージョン変更時表示、デモユーザー非表示
- [ ] /changelog ページ3言語表示
- [ ] CI version-bump ジョブ動作確認