### PR TITLE
fix(ci): version-bump の husky/npm-scripts エラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,12 +154,13 @@ jobs:
 
       - name: バージョンバンプ実行
         if: steps.bump.outputs.skip != 'true'
+        env:
+          HUSKY: '0'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git pull --rebase
-          # husky フックを無効化して npm version を実行（CI環境ではテスト不要）
-          HUSKY=0 npm version ${{ steps.bump.outputs.bump_type }} -m "[skip ci] chore(release): v%s"
+          npm version --ignore-scripts ${{ steps.bump.outputs.bump_type }} -m "[skip ci] chore(release): v%s"
 
       - name: CHANGELOG 生成
         if: steps.bump.outputs.skip != 'true'
@@ -167,7 +168,9 @@ jobs:
 
       - name: CHANGELOG コミット + push
         if: steps.bump.outputs.skip != 'true'
+        env:
+          HUSKY: '0'
         run: |
           git add CHANGELOG.md
-          HUSKY=0 git commit -m "[skip ci] docs: CHANGELOG.md を更新" || true
+          git commit -m "[skip ci] docs: CHANGELOG.md を更新" || true
           git push --follow-tags


### PR DESCRIPTION
## 概要
mainマージ時の version-bump ジョブで husky pre-commit フックが発動し、jest が見つからずエラーになっていた問題を修正。

## 原因
`npm version` が内部で git commit を実行 → husky pre-commit → `npm test` → `cd functions && npm test` → jest 未インストール（CI root の node_modules にはない）

## 修正内容
- `npm version --ignore-scripts` でライフサイクルスクリプトを無効化
- ステップレベルで `HUSKY: '0'` を環境変数に設定しフックも確実に無効化
- CHANGELOG コミット時も同様に `HUSKY: '0'` を設定

## テストプラン
- [ ] mainマージ後に version-bump ジョブが正常に完了すること