### PR TITLE
fix(seo): 内部リンク末尾スラッシュ統一 + 設定画面にブログリンク追加

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://obatlog.com/</loc><changefreq>weekly</changefreq><priority>1</priority></url>
-  <url><loc>https://obatlog.com/login/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://obatlog.com/blog/</loc><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://obatlog.com/blog/getting-started/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://obatlog.com/blog/notification-setup/</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/src/components/ChangelogPage.tsx
+++ b/src/components/ChangelogPage.tsx
@@ -25,7 +25,7 @@ export default function ChangelogPage() {
 
   return (
     <div className="max-w-lg mx-auto px-4 py-6 space-y-6">
-      <a href="/settings" className="text-sm text-gray-400 hover:text-gray-600">
+      <a href="/settings/" className="text-sm text-gray-400 hover:text-gray-600">
         {t('legal.back' as any, lang)}
       </a>
       <h1 className="text-xl font-bold text-gray-800">

--- a/src/components/DemoBanner.tsx
+++ b/src/components/DemoBanner.tsx
@@ -46,7 +46,7 @@ export default function DemoBanner({ expiresAtSeconds, isPC }: DemoBannerProps) 
       <span className="text-amber-600">{remainingLabel}</span>
       <span className="text-amber-600 mx-2">·</span>
       <a
-        href="/login"
+        href="/login/"
         className="text-amber-500 hover:text-amber-600 underline transition"
       >
         {t('demo.bannerSignUp' as any, lang)}

--- a/src/components/IntakeForm.tsx
+++ b/src/components/IntakeForm.tsx
@@ -153,7 +153,7 @@ export default function IntakeForm() {
       {meds.length === 0 ? (
         <div className="text-center py-8 space-y-2">
           <p className="text-gray-400">{t('empty.home.noMedications', lang)}</p>
-          <a href="/medications" className="text-amber-500 text-sm underline">
+          <a href="/medications/" className="text-amber-500 text-sm underline">
             {t('nav.medications', lang)} →
           </a>
         </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -30,11 +30,11 @@ export default function LandingPage() {
           {t('lp.hero.subtitle' as any, lang)}
         </p>
         <div className="flex flex-col items-center gap-3">
-          <a href="/login"
+          <a href="/login/"
             className="inline-block bg-amber-400 hover:bg-amber-500 text-white px-8 py-3 rounded-xl text-lg font-medium shadow-lg shadow-amber-200 transition">
             {t('lp.hero.cta' as any, lang)}
           </a>
-          <a href="/demo"
+          <a href="/demo/"
             className="inline-block text-amber-500 hover:text-amber-600 text-sm underline transition">
             {t('lp.hero.demo' as any, lang)}
           </a>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -122,9 +122,9 @@ export default function LoginForm() {
                   return (
                     <>
                       {parts[0]}
-                      <a href="/terms" className="underline hover:text-gray-600">{t('terms' as any, lang)}</a>
+                      <a href="/terms/" className="underline hover:text-gray-600">{t('terms' as any, lang)}</a>
                       {parts[1]}
-                      <a href="/privacy" className="underline hover:text-gray-600">{t('privacy' as any, lang)}</a>
+                      <a href="/privacy/" className="underline hover:text-gray-600">{t('privacy' as any, lang)}</a>
                       {parts[2]}
                     </>
                   );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -250,9 +250,10 @@ export default function SettingsPage() {
 
       {/* フッターリンク */}
       <section className="border-t pt-4 text-center text-xs text-gray-400 space-x-4">
-        <a href="/changelog" className="hover:text-gray-600">{t('settings.changelog' as any, lang)}</a>
-        <a href="/privacy" className="hover:text-gray-600">{t('nav.privacy' as any, lang)}</a>
-        <a href="/terms" className="hover:text-gray-600">{t('nav.terms' as any, lang)}</a>
+        <a href="/blog/" className="hover:text-gray-600">{t('settings.blog' as any, lang)}</a>
+        <a href="/changelog/" className="hover:text-gray-600">{t('settings.changelog' as any, lang)}</a>
+        <a href="/privacy/" className="hover:text-gray-600">{t('nav.privacy' as any, lang)}</a>
+        <a href="/terms/" className="hover:text-gray-600">{t('nav.terms' as any, lang)}</a>
       </section>
 
       {/* 言語ボトムシート */}

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -74,7 +74,7 @@ export default function UpdateModal({ isDemo }: UpdateModalProps) {
 
         <div className="flex flex-col gap-2 pt-2">
           <a
-            href="/changelog"
+            href="/changelog/"
             className="text-center text-sm text-amber-600 hover:text-amber-700 transition"
           >
             {t('update.showChangelog' as any, lang)}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -146,6 +146,7 @@
   "demo.bannerSignUp": "Create an account",
   "lp.hero.demo": "Try the demo",
   "settings.changelog": "Release Notes",
+  "settings.blog": "Developer Blog",
   "changelog.title": "Release Notes",
   "update.title": "App Updated",
   "update.message": "Updated to version {version}",

--- a/src/i18n/id.json
+++ b/src/i18n/id.json
@@ -146,6 +146,7 @@
   "demo.bannerSignUp": "Buat akun",
   "lp.hero.demo": "Coba demo",
   "settings.changelog": "Catatan Rilis",
+  "settings.blog": "Blog Developer",
   "changelog.title": "Catatan Rilis",
   "update.title": "Aplikasi Diperbarui",
   "update.message": "Diperbarui ke versi {version}",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -146,6 +146,7 @@
   "demo.bannerSignUp": "アカウントを作成する",
   "lp.hero.demo": "デモを試す",
   "settings.changelog": "更新履歴",
+  "settings.blog": "開発者ブログ",
   "changelog.title": "更新履歴",
   "update.title": "アップデートしました",
   "update.message": "バージョン {version} に更新されました",


### PR DESCRIPTION
## 概要
- GSC「リダイレクトがあります — 検出、インデックス未登録」対策
- ログイン後にブログへアクセスできない問題の修正

## 変更内容

### 末尾スラッシュ統一（GSCリダイレクト対策）
`trailingSlash: true` なのに `/blog` のようなスラッシュなしリンクが残っており、Firebase Hosting が 301 リダイレクトを返していた。全内部リンクを `/blog/` 形式に統一。

対象: LoginForm, ChangelogPage, IntakeForm, DemoBanner, LandingPage, UpdateModal, SettingsPage

### sitemap.xml から /login/ 除外
認証ページは noindex 対象なので sitemap に含めるべきではない。

### 設定画面にブログリンク追加
ログイン後のユーザーがブログにアクセスする導線がなかった。設定フッターに「開発者ブログ」リンクを追加（ja/en/id 多言語対応）。

## テストプラン
- [ ] 設定画面フッターに「開発者ブログ」リンクが表示される
- [ ] ブログリンクから /blog/ に遷移できる
- [ ] 全内部リンクが末尾スラッシュ付き（grep で確認済み）
- [ ] sitemap.xml に /login/ が含まれない
- [ ] `npx next build --webpack` が通る